### PR TITLE
Update Patcher.cpp

### DIFF
--- a/Patcher.cpp
+++ b/Patcher.cpp
@@ -16,6 +16,7 @@
 //#pragma warning(disable : 4996)
 
 #include "Patcher.h"
+#include <cstring>
 
 CPatcher::CPatcher(void)
 {


### PR DESCRIPTION
Solution error in ubuntu 16.04:
g++ -Wall -ansi    esrpatch.cpp Patcher.cpp   -o esrpatch
Patcher.cpp: In member function ‘int CPatcher::doPatch(char*)’:
Patcher.cpp:52:45: error: ‘strncmp’ was not declared in this scope
   if(!strncmp((char *)(buffer + 1), "NSR", 3)) {
                                             ^
Patcher.cpp:67:46: error: ‘strncmp’ was not declared in this scope
  if(!strncmp((char *)(buffer + 25), "+NSR", 4)) {
                                              ^
Patcher.cpp: In member function ‘int CPatcher::doUnPatch(char*)’:
Patcher.cpp:167:45: error: ‘strncmp’ was not declared in this scope
   if(!strncmp((char *)(buffer + 1), "NSR", 3)) {
                                             ^
Patcher.cpp:182:45: error: ‘strncmp’ was not declared in this scope
  if(strncmp((char *)(buffer + 25), "+NSR", 4)) {
                                             ^
Patcher.cpp:202:28: error: ‘memset’ was not declared in this scope
  memset(buffer, 0, LBA_SIZE);
